### PR TITLE
Parâmetro CodigoSeguranca incorreto

### DIFF
--- a/lib/aprova_facil/cartao_credito.rb
+++ b/lib/aprova_facil/cartao_credito.rb
@@ -86,7 +86,7 @@ class AprovaFacil
       params['NumeroCartao']                 = numero_cartao
       params['MesValidade']                  = '%02d' % mes_validade.to_i
       params['AnoValidade']                  = '%02d' % ano_validade
-      params['CodigoSeguranc']               = codigo_seguranca
+      params['CodigoSeguranca']              = codigo_seguranca
       params['PreAutorizacao']               = pre_autorizacao ? 'S' : 'N'
       params['EnderecoIPComprado']           = ip_comprador
       params['NomePortadorCarta']            = nome_portador if nome_portador

--- a/test/aprova_facil_test.rb
+++ b/test/aprova_facil_test.rb
@@ -8,12 +8,8 @@ class AprovaFacilTest < TestHelper
   end
   
   def test_aprovar
-    resultado = nil
-    3.times.each do 
-      resultado = @aprova_facil.aprovar cartao      
-      break if resultado[:aprovada]       
-    end
-    
+    resultado = @aprova_facil.aprovar cartao    
+
     assert_equal true, resultado[:aprovada] 
     assert_not_nil resultado[:resultado]     
     assert_not_nil resultado[:codigo_autorizacao]         
@@ -23,21 +19,14 @@ class AprovaFacilTest < TestHelper
   
   def test_aprovar_cartao_invalido
     cartao_invalido = cartao('502')
-    resultado = nil
-    3.times.each do     
-      resultado = @aprova_facil.aprovar cartao_invalido
-      break if !resultado[:aprovada]      
-    end
+
+    resultado = @aprova_facil.aprovar cartao_invalido
 
     assert_equal false, resultado[:aprovada]
   end
   
   def test_recobrar
-    resultado = nil
-    3.times.each do 
-      resultado = @aprova_facil.aprovar cartao      
-      break if resultado[:aprovada]
-    end
+    resultado = @aprova_facil.aprovar cartao
     assert_equal true, resultado[:aprovada]     
     
     resultado = @aprova_facil.capturar resultado[:transacao]


### PR DESCRIPTION
No método para aprovar uma transação, o parâmetro **CodigoSeguranca** está esta escrito incorretamente: **CodigoSeguranc**.

Com isso, ao enviar uma aprovação ao ambiente de testes do aprova fácil, a transação tinha um resultado aleatório. Sendo a transação algumas vezes aprovada e outras vezes reprovada.
