### PR TITLE
Adicionando número do documento em recobrar

### DIFF
--- a/lib/aprova_facil/aprova_facil.rb
+++ b/lib/aprova_facil/aprova_facil.rb
@@ -12,13 +12,14 @@ class AprovaFacil
   CANCELAR = 'CAN'
   
   # Método usado para efetuar cobraças recorrentes
-  def recobrar(transacao, valor, parcelas = '01', parcelamento_admin = true )
+  def recobrar(transacao, valor, parcelas = '01', parcelamento_admin = true, documento)
     request_url = url(COMPRAR)
     request_params = {
       'TransacaoAnterior' => transacao,
       'ValorDocumento' => valor,
       'QuantidadeParcelas' => '%02d' % parcelas,
-      'ParcelamentoAdministrador' => parcelamento_admin ? 'S' : 'N'
+      'ParcelamentoAdministrador' => parcelamento_admin ? 'S' : 'N',
+      'NumeroDocumento' => documento
     }
     xml_response = commit(request_url, request_params)
     treat_apc_response(xml_response)  


### PR DESCRIPTION
Olá!
Utilizo essa gem em um sistema legado.
Recentemente a API de recobrança foi alterada sem notificação por parte da Cobre Bem.
Ficamos 15 dias batendo cabeça por aqui, até que enfim o suporte me pediu desculpas, confirmando que houve uma alteração na API sem notificação aos desenvolvedores ou atualização na documentação.
Agora é necessário enviar o campo *NumeroDocumento* ao efetuar a requisição.